### PR TITLE
Fix incorrect identification of a number

### DIFF
--- a/src/scripts/storage.ts
+++ b/src/scripts/storage.ts
@@ -250,7 +250,7 @@ async function localGet(keys?: string | string[]): Promise<Local> {
 				const item = globalThis.localStorage.getItem(key)
 				const isJson = item && (item.startsWith('{') || item.startsWith('['))
 				const isBool = item && (item === 'true' || item === 'false')
-				const isNoom = item && Number.isNaN(Number.parseInt(item)) === false
+				const isNoom = item && Number.isNaN(Number(item)) === false
 
 				if (isJson) {
 					result[key] = parse(item)


### PR DESCRIPTION
The problem with Number.parseInt() is that it will always succeed if a string *starts with* a number.

Ie. The string "43fa4er2..." will be identified as a number and parsed as the number 43.

This caused the gist sync to fail when the uuid started with a number.