### PR TITLE
Fix empty todo/list lines persisting after deletion

### DIFF
--- a/src/scripts/features/notes.ts
+++ b/src/scripts/features/notes.ts
@@ -37,7 +37,7 @@ async function updateNotes(event: NotesEvent) {
 	}
 
 	if (event?.text !== undefined) {
-		notes.text = event.text
+		notes.text = sanitizeNotesText(event.text)
 	}
 
 	if (event?.align !== undefined) {
@@ -97,6 +97,19 @@ function handleBackground(hex = '#fff2') {
 		container?.classList.toggle('opaque', hex.includes('#fff') && opacityFromHex(hex) > 7)
 		document.documentElement.style.setProperty('--notes-background', hex)
 	}
+}
+
+function sanitizeNotesText(text: string): string {
+	return text
+		.split('\n')
+		.filter((line) => {
+			const trimmed = line.trim()
+			const isEmptyTodo = trimmed === '[ ]' || trimmed === '[x]'
+			const isEmptyList = trimmed === '-'
+			return !isEmptyTodo && !isEmptyList
+		})
+		.join('\n')
+		.replace(/\n{3,}/g, '\n\n')
 }
 
 function translateNotesText() {


### PR DESCRIPTION
## Problem
When deleting a line in the notes/todo feature, empty lines would sometimes persist - either as completely empty lines or as checkboxes without any text.

## Root Cause
The `pocket-editor` library's `toMarkdown()` function adds the checkbox prefix (`[ ]` or `[x]`) even when the line content is empty, resulting in strings like `"[ ] "` being saved. On reload, these get recreated as empty checkbox elements.

## Solution
Added a `sanitizeNotesText()` function that filters out:
- Empty todo lines (`[ ]`, `[x]`)
- Empty list items (`-`)
- Excessive consecutive newlines (3+ reduced to 2)

This sanitization happens before saving to storage, preventing empty lines from being persisted.

## Testing
- All existing tests pass
- Manually verified the fix works in local Chrome build