### PR TITLE
Fix link groups turning on when importing settings with on:false

### DIFF
--- a/src/scripts/compatibility/filters.ts
+++ b/src/scripts/compatibility/filters.ts
@@ -257,8 +257,8 @@ export function validateLinkGroups(current: Import): Import {
 		}
 	}
 
-	// Force enable if multiple groups are hidden
-	if (current.linkgroups.groups.length > 1) {
+	// Default to enabled if multiple groups exist and `on` wasn't explicitly set
+	if (current.linkgroups.groups.length > 1 && current.linkgroups.on === undefined) {
 		current.linkgroups.on = true
 	}
 


### PR DESCRIPTION
Fixes #688

## Problem
When importing a settings file where linkgroups are defined as `"on": false` and at least one link is present, the link groups feature is turned on after import, ignoring the user's explicit setting.

## Root Cause
In `validateLinkGroups()` filter (`filters.ts`), the code unconditionally sets `linkgroups.on = true` when multiple groups exist:

```javascript
// Force enable if multiple groups are hidden
if (current.linkgroups.groups.length > 1) {
    current.linkgroups.on = true
}
```

This overrides any explicitly set `on: false` value from the imported settings.

## Solution
Only default to `true` when the `on` property is `undefined` (not explicitly set), respecting user's explicit `on: false` setting:

```javascript
// Default to enabled if multiple groups exist and `on` wasn't explicitly set
if (current.linkgroups.groups.length > 1 && current.linkgroups.on === undefined) {
    current.linkgroups.on = true
}
```

## Testing
- All existing tests pass
- Verified the fix handles the case from the issue where importing with `"on": false` now respects that setting