### PR TITLE
Add line break support in quotes for poems and multi-line text

### DIFF
--- a/src/scripts/features/quotes.ts
+++ b/src/scripts/features/quotes.ts
@@ -282,7 +282,8 @@ function insertToDom(quote?: Quote) {
 		return
 	}
 
-	quoteDom.textContent = quote.content
+	// Convert escaped newlines (\n) to actual newlines for multi-line quotes (e.g., poems)
+	quoteDom.textContent = quote.content.replace(/\\n/g, '\n')
 	authorDom.textContent = quote.author
 }
 

--- a/src/styles/features/quotes.css
+++ b/src/styles/features/quotes.css
@@ -24,6 +24,7 @@
 	max-height: 9em;
 	margin-bottom: 0.75em;
 	overflow-y: clip;
+	white-space: pre-line;
 }
 
 #author {


### PR DESCRIPTION
Fixes #535

## Summary
Users can now add line breaks in custom quotes by using `\n` in their text. This is useful for displaying poems or other multi-line content.

## Example Usage
In the custom quotes textarea:
```
Shakespeare, To be or not to be\nThat is the question
```

Will display as:
> To be or not to be
> That is the question

## Changes
1. `src/styles/features/quotes.css` - Added `white-space: pre-line` to `#quote` element to render newline characters
2. `src/scripts/features/quotes.ts` - Convert `\n` escape sequences to actual newlines in `insertToDom()`

## Testing
- All existing tests pass
- The escaped newline approach preserves backward compatibility with existing CSV format