### PR TITLE
Auto-switch to imperial units based on user locale

### DIFF
--- a/src/scripts/defaults.ts
+++ b/src/scripts/defaults.ts
@@ -64,6 +64,13 @@ const DEFAULT_LANG = (() => {
 	return 'en'
 })()
 
+// Countries that use imperial units (Fahrenheit): US, Liberia, Myanmar, some Caribbean islands
+const DEFAULT_UNIT = (() => {
+	const locale = navigator.language?.toLowerCase() ?? ''
+	const imperialLocales = ['en-us', 'en-lr', 'my-mm', 'en-bs', 'en-bz', 'en-ky', 'en-pw']
+	return imperialLocales.some((l) => locale.startsWith(l)) ? 'imperial' : 'metric'
+})()
+
 export const SEARCHBAR_ENGINES = [
 	'default',
 	'google',
@@ -148,7 +155,7 @@ export const SYNC_DEFAULT: Sync = {
 	worldclocks: [],
 	weather: {
 		city: undefined,
-		unit: 'metric',
+		unit: DEFAULT_UNIT,
 		provider: '',
 		moreinfo: 'none',
 		forecast: 'auto',


### PR DESCRIPTION
Fixes #536

## Summary
Automatically detect if the user is in a country that uses imperial units (Fahrenheit) and set the default accordingly on first install.

## How It Works
On initial install, the extension checks `navigator.language` and sets the weather unit default to imperial for users in:
- United States (en-US)
- Liberia (en-LR)
- Myanmar (my-MM)
- Bahamas, Belize, Cayman Islands, Palau (en-BS, en-BZ, en-KY, en-PW)

All other locales default to metric (Celsius).

## Changes
`src/scripts/defaults.ts`:
- Added `DEFAULT_UNIT` constant that detects locale and returns appropriate unit
- Updated `SYNC_DEFAULT.weather.unit` to use `DEFAULT_UNIT` instead of hardcoded 'metric'

## Testing
- All existing tests pass
- Existing users are unaffected (their saved settings are preserved)
- Only affects new installations