### PR TITLE
feat: add duplicate link feature

### DIFF
--- a/_locales/en/translations.json
+++ b/_locales/en/translations.json
@@ -44,6 +44,7 @@
 	"Delete selected": "Delete selected",
 	"Remove from folder": "Remove from folder",
 	"Refresh icon": "Refresh icon",
+	"Duplicate": "Duplicate",
 	"Pin group": "Pin group",
 	"Unpin group": "Unpin group",
 	"Apply changes": "Apply changes",

--- a/src/index.html
+++ b/src/index.html
@@ -106,6 +106,24 @@
 					<span class="trn">Refresh icon</span>
 				</button>
 
+				<button type="submit" id="edit-duplicate">
+					<svg
+						xmlns="http://www.w3.org/2000/svg"
+						fill="none"
+						viewBox="0 0 24 24"
+						stroke-width="1.5"
+						stroke="currentColor"
+					>
+						<path
+							stroke-linecap="round"
+							stroke-linejoin="round"
+							d="M15.75 17.25v3.375c0 .621-.504 1.125-1.125 1.125h-9.75a1.125 1.125 0 0 1-1.125-1.125V7.875c0-.621.504-1.125 1.125-1.125H6.75a9.06 9.06 0 0 1 1.5.124m7.5 10.376h3.375c.621 0 1.125-.504 1.125-1.125V11.25c0-4.46-3.243-8.161-7.5-8.876a9.06 9.06 0 0 0-1.5-.124H9.375c-.621 0-1.125.504-1.125 1.125v3.5m7.5 10.375H9.375a1.125 1.125 0 0 1-1.125-1.125v-9.25m12 6.625v-1.875a3.375 3.375 0 0 0-3.375-3.375h-1.5a1.125 1.125 0 0 1-1.125-1.125v-1.5a3.375 3.375 0 0 0-3.375-3.375H9.75"
+						/>
+					</svg>
+
+					<span class="trn">Duplicate</span>
+				</button>
+
 				<button type="submit" id="edit-add">
 					<svg
 						xmlns="http://www.w3.org/2000/svg"

--- a/src/scripts/features/links/edit.ts
+++ b/src/scripts/features/links/edit.ts
@@ -194,7 +194,7 @@ function toggleEditInputs(): string[] {
 		} else if (target.folder) {
 			inputs = ['title', 'delete', 'apply']
 		} else if (target.link) {
-			inputs = ['title', 'url', 'icon', 'delete', 'refresh', 'apply']
+			inputs = ['title', 'url', 'icon', 'delete', 'duplicate', 'refresh', 'apply']
 		} else {
 			inputs = ['title', 'url', 'add']
 		}
@@ -326,6 +326,10 @@ function submitChanges(event: SubmitEvent) {
 
 	if (change === 'edit-refresh') {
 		quickLinks(undefined, { refreshIcons: selected })
+	}
+
+	if (change === 'edit-duplicate') {
+		quickLinks(undefined, { duplicateLink: selected[0] })
 	}
 
 	if (change === 'edit-inputs') {

--- a/src/scripts/features/links/index.ts
+++ b/src/scripts/features/links/index.ts
@@ -80,6 +80,7 @@ type LinksUpdate = {
 	moveOutFolder?: { ids: string[]; group: string }
 	deleteGroup?: string
 	deleteLinks?: string[]
+	duplicateLink?: string
 	refreshIcons?: string[]
 	groupTitle?: { old: string; new: string }
 	styles?: { style?: string; titles?: boolean; backgrounds?: boolean }
@@ -428,6 +429,9 @@ export async function linksUpdate(update: LinksUpdate) {
 	if (update.newtab !== undefined) {
 		data = setOpenInNewTab(update.newtab, data)
 	}
+	if (update.duplicateLink) {
+		data = duplicateLink(update.duplicateLink, data)
+	}
 	if (update.refreshIcons) {
 		data = refreshIcons(update.refreshIcons, data)
 	}
@@ -657,6 +661,31 @@ function moveToGroup({ ids, target }: MoveToGroup, data: Sync): Sync {
 
 	const correctdata = correctLinksOrder(data)
 	initblocks(correctdata)
+	return correctdata
+}
+
+function duplicateLink(id: string, data: Sync): Sync {
+	const sourceLink = data[id] as Link
+
+	if (!sourceLink || sourceLink.folder) {
+		return data
+	}
+
+	const newId = `links${randomString(6)}`
+	const newLink: LinkElem = {
+		_id: newId,
+		title: sourceLink.title,
+		url: (sourceLink as LinkElem).url,
+		icon: (sourceLink as LinkElem).icon,
+		parent: sourceLink.parent,
+		order: sourceLink.order + 0.5,
+	}
+
+	data[newId] = newLink
+
+	const correctdata = correctLinksOrder(data)
+	initblocks(correctdata)
+
 	return correctdata
 }
 


### PR DESCRIPTION
## Summary
Adds a 'Duplicate' button to the link context menu that creates a copy of the selected link immediately after the original.

## Changes
- Added duplicate button to edit link dialog in `src/index.html` with copy icon
- Added "Duplicate" translation in `_locales/en/translations.json`
- Updated `edit.ts` to show duplicate button for links and handle `edit-duplicate` event
- Added `duplicateLink` to `LinksUpdate` type and implemented the duplication logic in `index.ts`

## How it works
When duplicating a link:
1. The source link's properties (title, url, icon, parent) are copied
2. A new unique ID is generated
3. The duplicate is placed immediately after the original (using order + 0.5)
4. Link order is corrected to maintain proper sequencing

## Testing
- All existing tests pass
- Type checking passes

Closes #606